### PR TITLE
docs: add Japanese documentation comments

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,8 +1,15 @@
+/**
+ * ページ上でテキスト要素を選択して収集するコンテンツスクリプト。
+ */
+// コンテンツスクリプトの初期化ログ
 console.log('[SC] loaded', location.href);
 
+// 選択した要素をハイライトする CSS スタイル
 const HIGHLIGHT_STYLE =
   'outline: 2px solid rgba(255,0,0,.7); outline-offset: 2px;';
+// 選択モードが有効かどうか
 let selecting = false;
+// クリックで収集したテキストのキュー
 let queue = [];
 
 // ── message handler ────────────────────────────────────────────
@@ -20,16 +27,25 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
 });
 
+/**
+ * 選択モードを有効化し、クリックイベントを捕捉する。
+ */
 function enable() {
   document.addEventListener('click', onClick, true);
   document.body.style.cursor = 'crosshair';
 }
 
+/**
+ * 選択モードを無効化して状態を元に戻す。
+ */
 function disable() {
   document.removeEventListener('click', onClick, true);
   document.body.style.cursor = '';
 }
 
+/**
+ * クリックされた要素からテキストを取得し、キューに追加する。
+ */
 function onClick(e) {
   if (!selecting) return;
   e.preventDefault();
@@ -45,6 +61,9 @@ function onClick(e) {
   chrome.storage.local.set({ textQueue: queue });
 }
 
+/**
+ * 一時的に要素をハイライト表示する。
+ */
 function flash(el) {
   const prev = el.getAttribute('data-sc-prev') ?? '';
   if (!el.hasAttribute('data-sc-prev'))

--- a/src/utils/selectorBuider.js
+++ b/src/utils/selectorBuider.js
@@ -1,6 +1,6 @@
 /**
- * Build a unique & stable CSS selector for a DOM element.
- * Falls back to XPath when a safe CSS path is impossible (e.g. in SVG or selector‑hostile markup).
+ * DOM 要素に対してユニークで安定したセレクタを生成する。
+ * セレクタの生成が難しい場合は XPath にフォールバックする。
  */
 export function buildSelector(el, { preferCss = true } = {}) {
   if (preferCss) {
@@ -10,6 +10,9 @@ export function buildSelector(el, { preferCss = true } = {}) {
   return getXPath(el);
 }
 
+/**
+ * 要素から CSS セレクタのパスを構築する。
+ */
 function cssPath(el) {
   if (el.id) return `#${CSS.escape(el.id)}`;
   const path = [];
@@ -26,6 +29,9 @@ function cssPath(el) {
   return path.join(' > ');
 }
 
+/**
+ * 生成したセレクタが一意かどうかを判定する。
+ */
 function isUniqueSelector(el, selector) {
   try {
     const matches = el.ownerDocument.querySelectorAll(selector);
@@ -35,6 +41,9 @@ function isUniqueSelector(el, selector) {
   }
 }
 
+/**
+ * 再帰的に XPath を構築する。
+ */
 function getXPath(el) {
   if (el.id) return `//*[@id="${el.id}"]`;
   return (


### PR DESCRIPTION
## Summary
- add Japanese doc comments to content script
- document selector builder utility in Japanese

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891d24df1f0832d8038c04e75edd007